### PR TITLE
[FEATURE] Fix hosts for development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,9 +69,8 @@ Rails.application.configure do
   # config.action_cable.disable_request_forgery_protection = true
 
   # Add initial ActionCable host
-  config.action_cable.allowed_request_origins = 'localhost:3000'
+  config.action_cable.allowed_request_origins = ['https://localhost:3000', 'http://localhost:3000', 'https://scada.of.the.legendary.armor.quest']
 
   # Add a Caddy HTTPS host
   config.hosts << 'scada.of.the.legendary.armor.quest'
-  config.action_cable.allowed_request_origins << 'scada.of.the.legendary.armor.quest'
 end


### PR DESCRIPTION
Action cable won't allow for the websocket to connect during development without caddy due to origins not being set correctly.